### PR TITLE
Fix issue where reference to csv object in CSV.Open is lost, thus not…

### DIFF
--- a/lib/csv-diff/csv_source.rb
+++ b/lib/csv-diff/csv_source.rb
@@ -104,7 +104,11 @@ class CSVDiff
                 mode_string = options[:encoding] ? "r:#{options[:encoding]}" : 'r'
                 csv_options = options.fetch(:csv_options, {})
                 @path = source
-                source = CSV.open(@path, mode_string, csv_options).readlines
+                # When you call CSV.open, it's best to pass in a block so that after it's yielded,
+                # the underlying file handle is closed. Otherwise, you risk leaking the handle.
+                CSV.open(@path, mode_string, csv_options) do |csv|
+                    source = temp_csv.readlines
+                end
             elsif !source.is_a?(Enumerable) || (source.is_a?(Enumerable) && source.size > 0 &&
                                                 !source.first.is_a?(Enumerable))
                 raise ArgumentError, "source must be a path to a file or an Enumerable<Enumerable>"

--- a/lib/csv-diff/csv_source.rb
+++ b/lib/csv-diff/csv_source.rb
@@ -107,7 +107,7 @@ class CSVDiff
                 # When you call CSV.open, it's best to pass in a block so that after it's yielded,
                 # the underlying file handle is closed. Otherwise, you risk leaking the handle.
                 CSV.open(@path, mode_string, csv_options) do |csv|
-                    source = temp_csv.readlines
+                    source = csv.readlines
                 end
             elsif !source.is_a?(Enumerable) || (source.is_a?(Enumerable) && source.size > 0 &&
                                                 !source.first.is_a?(Enumerable))


### PR DESCRIPTION
… releasing the file handle

`CSV.open` has a design flaw where the underlying file handle gets lost if you chain a call after it. This is an issue if you need to, for one example, delete the file used as the source after you are done diffing/parsing/etc. The CSV class doesn't let go of the handle and you can't get it back. 

For example, if you do `CSV.open(@path, mode_string, csv_options).readlines`, as is done at https://github.com/agardiner/csv-diff/blob/abff443e856e9d88f711a4d6bcc688c8c6ab7139/lib/csv-diff/csv_source.rb#L107, the results of `readlines` is returned, and you lose reference to the file handle used within `CSV.open`.

This PR gets around this issue by passing a block to `CSV.open`, which per its implementation, closes the file after the block has been yielded. 

See https://github.com/ruby/csv/blob/8e4f837a2cbf7fb005fa3d965226529fd6cb9d1c/lib/csv.rb#L634 to better understand how `CSV.open` is implemented and why this is an issue. 

This has been tested on both Windows and Ubuntu. 